### PR TITLE
Change autocompletion dialog's background to simple black-and-white

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -256,10 +256,10 @@ module Reline
         contents: result,
         scrollbar: true,
         height: 15,
-        bg_color: 46,
-        pointer_bg_color: 45,
+        bg_color: 40,
         fg_color: 37,
-        pointer_fg_color: 37
+        pointer_bg_color: 47,
+        pointer_fg_color: 30
       )
     }
     Reline::DEFAULT_DIALOG_CONTEXT = Array.new


### PR DESCRIPTION
The default light background (cyan) has low contrast with the white text. And it's making autocompletion's texts hard to read, as demonstrated in

https://bugs.ruby-lang.org/issues/18996

So even though we can't let users customise desirable colors yet, we can still improve it by adopting simpler black and white.